### PR TITLE
AP-1199 update android schema validation for location

### DIFF
--- a/docs/android/location/002.json
+++ b/docs/android/location/002.json
@@ -17,8 +17,7 @@
                 "maximum": 180
             },
             "accuracy": {
-                "type": "number",
-                "minimum": 0
+                "type": "number"
             },
             "provider": {
                 "type": "string"


### PR DESCRIPTION
this fixes the annoying prod bug

Error on control-mt
stdout:
Data Push request
Failed
Invalid data for schema: http://schemas.datacubed.com/android/location/002.json. Error: -2147223.25 is less than the minimum of 0