### PR TITLE
AP-1831-add-instrument-id-to-schema

### DIFF
--- a/docs/platform/study_conditions.json
+++ b/docs/platform/study_conditions.json
@@ -109,7 +109,8 @@
                 "required": [
                   "instrument_score",
                   "logical_operator",
-                  "window"
+                  "window",
+                  "instrument_id"
                 ],
                 "properties": {
                   "instrument_score": {
@@ -122,6 +123,11 @@
                     "$id": "#root/conditions/items/triggers/items/resource_function_params/window",
                     "title": "Window",
                     "type": "integer"
+                  },
+                  "instrument_id": {
+                    "$id": "#root/conditions/items/triggers/items/resource_function_params/instrument_id",
+                    "title": "Instrument_id",
+                    "type": "string"
                   },
                   "logical_operator": {
                     "$id": "#root/conditions/items/triggers/items/resource_function_params/logical_operator",


### PR DESCRIPTION
PR addresses:
As per call after standup 08/05 - add instrument-id to the trigger parameter

Testing:

- go to https://www.jsonschemavalidator.net/
- validate this schema against an old condition attached in json with medication_adherence trigger and "send_push_notification" action
- validate this schema against and new condition with instrument-scoring trigger and "create_virtual_visit_emergency_call" action